### PR TITLE
Improve radiation module (part 2)

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -428,8 +428,8 @@ WarpX::OneStep_nosub (Real cur_time)
     ExecutePythonCallback("particlescraper");
     ExecutePythonCallback("beforedeposition");
 
-    //Save particle old momentum in a attribute
-    mypc->keepoldmomentum();
+    //Save particles' old momenta
+    mypc->RecordOldMomenta();
 
     PushParticlesandDeposit(cur_time);
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -332,8 +332,7 @@ public:
 
     void doRadiation(amrex::Real dt, amrex::Real cur_time);
 
-    void keepoldmomentum();
-    void keepoldmomentum_p(std::unique_ptr<WarpXParticleContainer>& pc);
+    void RecordOldMomenta();
 
     void Dump_radiations();
     [[nodiscard]] int getSpeciesID (std::string product_str) const;

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -20,7 +20,7 @@
 #   include "Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper_fwd.H"
 #endif
 #include "PhysicalParticleContainer.H"
-#include "Particles/Radiation/RadiationHandler.H"
+#include "Particles/Radiation/RadiationHandler_fwd.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
 #include "WarpXParticleContainer.H"
@@ -69,7 +69,7 @@ public:
 
     MultiParticleContainer (amrex::AmrCore* amr_core);
 
-    ~MultiParticleContainer() = default;
+    ~MultiParticleContainer();
 
     MultiParticleContainer (MultiParticleContainer const &)             = delete;
     MultiParticleContainer& operator= (MultiParticleContainer const & ) = delete;

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -125,7 +125,6 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
     collisionhandler = std::make_unique<CollisionHandler>(this);
     //Initialization of the radiation
     for (auto& s : allcontainers) {
-        amrex::Print() << s->has_radiation() <<"jzfnfhjzbefhezbfhzebfzehb" << "\n";
         if (s->has_radiation()) {
             m_at_least_one_has_radiation = true;
             m_p_radiation_handler = std::make_unique<RadiationHandler>();

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -29,6 +29,7 @@
 #include "Particles/ParticleCreation/SmartUtils.H"
 #include "Particles/PhotonParticleContainer.H"
 #include "Particles/PhysicalParticleContainer.H"
+#include "Particles/Radiation/RadiationHandler.H"
 #include "Particles/RigidInjectedParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "SpeciesPhysicalProperties.H"
@@ -132,6 +133,8 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
         }
     }
 }
+
+MultiParticleContainer::~MultiParticleContainer() {}
 
 void
 MultiParticleContainer::ReadParameters ()

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -122,13 +122,11 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
 
     // Setup particle collisions
     collisionhandler = std::make_unique<CollisionHandler>(this);
-    amrex::Print() << "wEEEEEEEESSSSSSSHHHHH" << allcontainers.size() << "\n";
     //Initialization of the radiation
     for (auto& s : allcontainers) {
         amrex::Print() << s->has_radiation() <<"jzfnfhjzbefhezbfhzebfzehb" << "\n";
         if (s->has_radiation()) {
             m_at_least_one_has_radiation = true;
-            amrex::Print() << "Hey ! I'm here" << "\n";
             m_p_radiation_handler = std::make_unique<RadiationHandler>();
             break;
         }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -347,15 +347,11 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 
     //check if Radiation Reaction is enabled and do consistency checks
     pp_species_name.query("do_classical_radiation_reaction", do_classical_radiation_reaction);
-    //check if Radiations are enables for species and add previous momentum attribute
+
+    //check if Radiations are enables for species and add old momentum attribute
     pp_species_name.query("do_radiation", m_do_radiation);
-    if (m_do_radiation==1){
-        amrex::Print() << "i'm here";
-        //enable the radiations in the evolve loop
-        AddRealComp("prev_u_x");
-        AddRealComp("prev_u_y");
-        AddRealComp("prev_u_z");
-    }
+    if (m_do_radiation==1) {AllocateOldMomenta();}
+
     //if the species is not a lepton, do_classical_radiation_reaction
     //should be false
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/Source/Particles/Radiation/RadiationHandler.H
+++ b/Source/Particles/Radiation/RadiationHandler.H
@@ -13,12 +13,10 @@
 
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/Sorting/SortingUtils.H"
-#include "WarpX.H"
 
+#include <AMReX_GpuContainers.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
-#include <AMReX_Geometry.H>
-
 
 #include <memory>
 #include <string>

--- a/Source/Particles/Radiation/RadiationHandler.H
+++ b/Source/Particles/Radiation/RadiationHandler.H
@@ -27,17 +27,17 @@
 class RadiationHandler
 {
 public:
-    RadiationHandler ();
+    RadiationHandler (const amrex::Array<amrex::Real,3>& center);
 
     /* Perform the calculation of the radiation */
     //void doRadiation (amrex::Real dt, MultiParticleContainer* mypc);
     void add_radiation_contribution(const amrex::Real dt, std::unique_ptr<WarpXParticleContainer>& pc, amrex::Real current_time);
-    void add_detector();
     void gather_and_write_radiation(const std::string& filename);
     void Integral_overtime();
 
 
 private:
+    void add_detector(const amrex::Array<amrex::Real,3>& center);
 
     // Frequency range
     amrex::Vector<amrex::Real> m_omega_range;

--- a/Source/Particles/Radiation/RadiationHandler.H
+++ b/Source/Particles/Radiation/RadiationHandler.H
@@ -6,24 +6,24 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#ifndef WARPX_PARTICLES_RADIATION_H_
-#define WARPX_PARTICLES_RADIATION_H_
-#include "Particles/Pusher/GetAndSetPosition.H"
+#ifndef WARPX_PARTICLES_RADIATION_H
+#define WARPX_PARTICLES_RADIATION_H
 
+#include "RadiationHandler_fwd.H"
+
+#include "Particles/Pusher/GetAndSetPosition.H"
+#include "Particles/Sorting/SortingUtils.H"
+#include "WarpX.H"
 
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
-#include <AMReX_Box.H>
-#include <AMReX_Vector.H>
-#include <AMReX_FArrayBox.H>
 #include <AMReX_Geometry.H>
 
-#include "WarpX.H"
-#include "Particles/Sorting/SortingUtils.H"
+
 #include <memory>
 #include <string>
 
-/* \brief CollisionHandler is a light weight class that contains the
+/* \brief CollisionHandler is a class that contains the
  * calculation of radiation for particles at each frequencies and angles.
  */
 class RadiationHandler
@@ -82,4 +82,4 @@ private:
     amrex::Vector<amrex::Real> omega_calc;
 
 };
-#endif // WARPX_PARTICLES_RADIATION_H_
+#endif // WARPX_PARTICLES_RADIATION_H

--- a/Source/Particles/Radiation/RadiationHandler.cpp
+++ b/Source/Particles/Radiation/RadiationHandler.cpp
@@ -18,7 +18,7 @@
 
 using namespace ablastr::math;
 
-RadiationHandler::RadiationHandler()
+RadiationHandler::RadiationHandler(const amrex::Array<amrex::Real,3>& center)
 {
     // Read in radiation input
     const amrex::ParmParse pp_radiations("radiations");
@@ -43,7 +43,8 @@ RadiationHandler::RadiationHandler()
         pp_radiations.getarr("detector_number_points", m_det_pts,0,2);
         pp_radiations.getarr("detector_direction", m_det_direction,0,3);
         pp_radiations.query("detector_distance", m_det_distance);
-        add_detector();
+
+        add_detector(center);
          /* Initialize the Fab with the field in function of angle and frequency */
          //int numcomps = 4;
         //BaseFab<Complex> fab(bx,numcomps);
@@ -93,13 +94,13 @@ void RadiationHandler::add_radiation_contribution
                     auto& part=pc->GetParticles(level0)[index];
                     auto& soa = part.GetStructOfArrays();
 
-                    const auto prev_u_x_idx =pc->GetRealCompIndex("prev_u_x");
-                    const auto prev_u_y_idx =pc->GetRealCompIndex("prev_u_y");
-                    const auto prev_u_z_idx =pc->GetRealCompIndex("prev_u_z");
+                    const auto old_u_x_idx =pc->GetRealCompIndex("old_u_x");
+                    const auto old_u_y_idx =pc->GetRealCompIndex("old_u_y");
+                    const auto old_u_z_idx =pc->GetRealCompIndex("old_u_z");
 
-                    auto* p_ux_old = soa.GetRealData(prev_u_x_idx).data();
-                    auto* p_uy_old = soa.GetRealData(prev_u_y_idx).data();
-                    auto* p_uz_old = soa.GetRealData(prev_u_z_idx).data();
+                    auto* p_ux_old = soa.GetRealData(old_u_x_idx).data();
+                    auto* p_uy_old = soa.GetRealData(old_u_y_idx).data();
+                    auto* p_uz_old = soa.GetRealData(old_u_z_idx).data();
 
                     auto GetPosition = GetParticlePosition<PIdx>(pti);
                     amrex::ParticleReal const q = pc->getCharge();
@@ -200,10 +201,8 @@ void RadiationHandler::gather_and_write_radiation(const std::string& filename)
         of.close();
     }
 }
-void RadiationHandler::add_detector
-    (){
-    const auto level0=0;
-    amrex::Geometry const& geom = WarpX::GetInstance().Geom(level0);
+void RadiationHandler::add_detector(const amrex::Array<amrex::Real,3>& center){
+
     //Calculation of angle resolution
     m_d_theta.resize(2);
     for(int i=0; i<2; i++){
@@ -211,11 +210,7 @@ void RadiationHandler::add_detector
     }
     //Set the resolution of the detector
     m_d_d.resize(3);
-    amrex::Vector<amrex::Real> center;
-    center.resize(3);
-    for(int idim=0; idim<AMREX_SPACEDIM; idim++){
-        center[idim] = (geom.ProbHi()[idim]+geom.ProbLo()[idim])/2;
-    }
+
     for(int idi = 0; idi<3; ++idi){
         if(m_det_direction[idi]==1){
             m_d_d[(idi+1)%3]=2*m_det_distance*tan(m_d_theta[0]/2);

--- a/Source/Particles/Radiation/RadiationHandler.cpp
+++ b/Source/Particles/Radiation/RadiationHandler.cpp
@@ -233,7 +233,6 @@ void RadiationHandler::add_detector
         det_bornes[idim][0]=center[idim]-std::tan(m_theta_range[idim]/2)*m_det_distance;
         det_bornes[idim][1]=center[idim]+std::tan(m_theta_range[idim]/2)*m_det_distance;
     }
-    //fillWithConsecutiveReal(pos_det_x)
     //pos_det_y
     //omega_calc
 

--- a/Source/Particles/Radiation/RadiationHandler_fwd.H
+++ b/Source/Particles/Radiation/RadiationHandler_fwd.H
@@ -1,0 +1,17 @@
+
+/* Copyright 2023 Thomas Clark, Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_PARTICLES_RADIATION_FWD_H
+#define WARPX_PARTICLES_RADIATION_FWD_H
+
+/* \brief CollisionHandler is a class that contains the
+ * calculation of radiation for particles at each frequencies and angles.
+ */
+class RadiationHandler;
+
+#endif // WARPX_PARTICLES_RADIATION_FWD_H

--- a/Source/Particles/Sorting/SortingUtils.H
+++ b/Source/Particles/Sorting/SortingUtils.H
@@ -21,14 +21,6 @@
  */
 void fillWithConsecutiveIntegers( amrex::Gpu::DeviceVector<long>& v );
 
-/** \brief Fill the elements of the input vector with consecutive integer,
- *        starting from 0
- *
- * \param[inout] v Vector of reals, to be filled by this routine
- */
-
-void fillWithConsecutiveReal( amrex::Gpu::DeviceVector<amrex::Real>& v );
-
 
 /** \brief Find the indices that would reorder the elements of `predicate`
  * so that the elements with non-zero value precede the other elements

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -407,6 +407,19 @@ public:
     void defineAllParticleTiles () noexcept;
 
 protected:
+
+    /**
+     * This function allocates three real components:
+     * old_u_x, old_u_y, old_u_z.
+     */
+    void AllocateOldMomenta();
+
+    /**
+     * This function copies the momenta of the particles into:
+     * old_u_x, old_u_y, old_u_z.
+     */
+    void RecordOldMomenta();
+
     int species_id;
 
     amrex::ParticleReal charge;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1415,3 +1415,44 @@ WarpXParticleContainer::ApplyBoundaryConditions (){
         }
     }
 }
+
+void WarpXParticleContainer::AllocateOldMomenta()
+{
+    AddRealComp("old_u_x");
+    AddRealComp("old_u_y");
+    AddRealComp("old_u_z");
+}
+
+void WarpXParticleContainer::RecordOldMomenta()
+{
+    auto const nlevs = std::max(0, finestLevel()+1);
+    for (int lev = 0; lev < nlevs; ++lev) {
+
+#ifdef AMREX_USE_OMP
+        #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        {
+            for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti) {
+                auto index = std::make_pair(pti.index(), pti.LocalTileIndex());
+                auto& part= GetParticles(lev)[index];
+                auto const np = pti.numParticles();
+                auto& soa = part.GetStructOfArrays();
+
+                const auto* ux = soa.GetRealData(PIdx::ux).data();
+                const auto* uy = soa.GetRealData(PIdx::uy).data();
+                const auto* uz = soa.GetRealData(PIdx::uz).data();
+
+                auto* old_ux = soa.GetRealData(GetRealCompIndex("old_u_x")).data();
+                auto* old_uy = soa.GetRealData(GetRealCompIndex("old_u_y")).data();
+                auto* old_uz = soa.GetRealData(GetRealCompIndex("old_u_z")).data();
+
+                amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int ip) {
+                    old_ux[ip] = ux[ip];
+                    old_uy[ip] = uy[ip];
+                    old_uz[ip] = uz[ip];
+                });
+
+            }
+        }
+    }
+}

--- a/Source/ablastr/math/Complex.H
+++ b/Source/ablastr/math/Complex.H
@@ -31,6 +31,6 @@ namespace ablastr::math
 
     static_assert(sizeof(Complex) == sizeof(amrex::Real[2]),
         "Unexpected complex type.");
-};
+}
 
 #endif //ABLASTR_MATH_COMPLEX_H_


### PR DESCRIPTION
The changes include:
- using forward declaration for radiation module
- replacing `keepoldmomentum` and `keepoldmomentum_p` with a `RecordOldMomenta` function defined for `WarpXParticleContainer`
- Avoid using `WarpX::GetInstance`
